### PR TITLE
Adds custom text file option

### DIFF
--- a/FaxanaduRando/FaxanaduRando.csproj
+++ b/FaxanaduRando/FaxanaduRando.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Randomizer\Table.cs" />
     <Compile Include="Randomizer\Text.cs" />
     <Compile Include="Randomizer\TextObject.cs" />
+    <Compile Include="Randomizer\TextOptions.cs" />
     <Compile Include="Randomizer\TextRandomizer.cs" />
     <Compile Include="Randomizer\Towns.cs" />
     <Compile Include="Randomizer\Trunk.cs" />

--- a/FaxanaduRando/MainWindow.xaml
+++ b/FaxanaduRando/MainWindow.xaml
@@ -135,6 +135,7 @@
                             <Binding ElementName="randomizeTitlesCheckBox" Path="IsChecked" />
                             <Binding ElementName="includeSomeEolisDoorsCheckBox" Path="IsChecked" />
                             <Binding ElementName="addKillSwitchCheckBox" Path="IsChecked" />
+                            <Binding ElementName="useCustomTextCheckBox" Path="IsChecked" />
                             <Binding ElementName="hintsComboBox" Path="SelectedIndex" />
                             <Binding ElementName="miscDoorsComboBox" Path="SelectedIndex" />
                             <Binding ElementName="worldDoorsComboBox" Path="SelectedIndex" />
@@ -640,6 +641,11 @@
 
                 <TextBox Name ="customTextPathTextBox" Grid.Column="0" Grid.Row="1"/>
                 <Button Content="Browse" Grid.Column="1" Grid.Row="1" Click="CustomTextBrowseButton_Click"/>
+
+                <CheckBox Name="useCustomTextCheckBox" Grid.Column="2" Grid.Row="0" IsChecked="{Binding Path=(randomizer:TextOptions.UseCustomText), Mode=TwoWay}"
+                          ToolTip="Use custom text from a text file"/>
+                <TextBlock Grid.Column="3" Grid.Row="0" Text="Use custom text"/>
+
             </Grid>
         </TabItem>
     </TabControl>

--- a/FaxanaduRando/MainWindow.xaml
+++ b/FaxanaduRando/MainWindow.xaml
@@ -618,5 +618,29 @@
                 </StackPanel>
             </Grid>
         </TabItem>
+        <TabItem Header="Custom Text">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock Grid.Column="0" Grid.Row="0" Text="Custom Text File Path"/>
+
+                <TextBox Name ="customTextPathTextBox" Grid.Column="0" Grid.Row="1"/>
+                <Button Content="Browse" Grid.Column="1" Grid.Row="1" Click="CustomTextBrowseButton_Click"/>
+            </Grid>
+        </TabItem>
     </TabControl>
 </Window>

--- a/FaxanaduRando/MainWindow.xaml.cs
+++ b/FaxanaduRando/MainWindow.xaml.cs
@@ -120,31 +120,31 @@ namespace FaxanaduRando
                 var box = (System.Windows.Controls.ComboBox)sender;
                 if (box.SelectedIndex == 0)
                 {
-                    flagsTextBox.Text = "30B9FF725k02v1ma";
+                    flagsTextBox.Text = "30B9FF7205k02v1ma";
                 }
                 else if (box.SelectedIndex == 1)
                 {
-                    flagsTextBox.Text = "7E9FFF7Aza0cFbka";
+                    flagsTextBox.Text = "7E9FFF7AAza0cFbka";
                 }
                 else if (box.SelectedIndex == 2)
                 {
-                    flagsTextBox.Text = "7E9FFF7Azc0aPaka";
+                    flagsTextBox.Text = "7E9FFF7AAzc0aPaka";
                 }
                 else if (box.SelectedIndex == 3)
                 {
-                    flagsTextBox.Text = "50105E00Am00Zocmk";
+                    flagsTextBox.Text = "50105E000Am00Zocmk";
                 }
                 else if (box.SelectedIndex == 4)
                 {
-                    flagsTextBox.Text = "7E995E6Axe0bPakk";
+                    flagsTextBox.Text = "7E995E6AAxe0bPakk";
                 }
                 else if (box.SelectedIndex == 5)
                 {
-                    flagsTextBox.Text = "7E9FFFFEucma0aa0";
+                    flagsTextBox.Text = "7E9FFFFAEucma0aa0";
                 }
                 else if (box.SelectedIndex == 6)
                 {
-                    flagsTextBox.Text = "3EDFFFFAAl02vbma";
+                    flagsTextBox.Text = "3EDFFFFAAAl02vbma";
                 }
             }
         }

--- a/FaxanaduRando/MainWindow.xaml.cs
+++ b/FaxanaduRando/MainWindow.xaml.cs
@@ -39,6 +39,31 @@ namespace FaxanaduRando
             }
         }
 
+        private void CustomTextBrowseButton_Click(object sender, RoutedEventArgs e)
+        {
+            var openFileDialog = new OpenFileDialog()
+            {
+                Title = "Select Custom Text File",
+
+                CheckFileExists = true,
+                CheckPathExists = true,
+
+                DefaultExt = "txt",
+                Filter = "txt files (*.txt)|*.txt",
+                FilterIndex = 2,
+
+                ReadOnlyChecked = true,
+                ShowReadOnly = true
+            };
+
+            bool? result = openFileDialog.ShowDialog();
+            if (result == true)
+            {
+                customTextPathTextBox.Text = openFileDialog.FileName;
+            }
+        }
+
+
         private void NewSeedButton_Click(object sender, RoutedEventArgs e)
         {
             var random = new Random();
@@ -74,7 +99,7 @@ namespace FaxanaduRando
             {
                 var randomizer = new Randomizer.Randomizer();
                 string message;
-                bool result = randomizer.Randomize(pathTextBox.Text, flagsTextBox.Text, seed, out message);
+                bool result = randomizer.Randomize(pathTextBox.Text, customTextPathTextBox.Text, flagsTextBox.Text, seed, out message);
                 if (!result)
                 {
                     MessageBox.Show(message, "Failed");

--- a/FaxanaduRando/Randomizer/FlagConverter.cs
+++ b/FaxanaduRando/Randomizer/FlagConverter.cs
@@ -8,7 +8,7 @@ namespace FaxanaduRando.Randomizer
 {
     class FlagConverter : IMultiValueConverter
     {
-        private const int boolCount = 32;
+        private const int boolCount = 33;
 
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {

--- a/FaxanaduRando/Randomizer/Randomizer.cs
+++ b/FaxanaduRando/Randomizer/Randomizer.cs
@@ -6,7 +6,7 @@ namespace FaxanaduRando.Randomizer
 {
     public class Randomizer
     {
-        public bool Randomize(string inputFile, string flags, int seed, out string message)
+        public bool Randomize(string inputFile, string customTextFile, string flags, int seed, out string message)
         {
             message = "Failed to find a valid randomization for this seed";
             Random random = new Random(seed);
@@ -299,10 +299,10 @@ namespace FaxanaduRando.Randomizer
             var textRandomizer = new TextRandomizer(content, random);
             if (GeneralOptions.RandomizeTitles)
             {
-                textRandomizer.RandomizeTitles(content);
+                textRandomizer.RandomizeTitles(content, customTextFile);
             }
 
-            if (!textRandomizer.UpdateText(shopRandomizer, giftRandomizer, doorRandomizer, content))
+            if (!textRandomizer.UpdateText(shopRandomizer, giftRandomizer, doorRandomizer, content, customTextFile))
             {
                 return false;
             }

--- a/FaxanaduRando/Randomizer/Randomizer.cs
+++ b/FaxanaduRando/Randomizer/Randomizer.cs
@@ -4,11 +4,24 @@ using System.IO;
 
 namespace FaxanaduRando.Randomizer
 {
+    public enum Result
+    {
+        Success,
+        failure,
+        TextTooLong,
+    }
+
     public class Randomizer
     {
         public bool Randomize(string inputFile, string customTextFile, string flags, int seed, out string message)
         {
-            message = "Failed to find a valid randomization for this seed";
+            if (TextOptions.UseCustomText &&
+                string.IsNullOrEmpty(customTextFile))
+            {
+                message = "Please supply a path to a text file when using custom text. For a reference to the format of the file, check the Readme file";
+                return false;
+            }
+
             Random random = new Random(seed);
 
 #if !DEBUG
@@ -33,10 +46,11 @@ namespace FaxanaduRando.Randomizer
             {
                 foreach (var level in levels)
                 {
-                    bool result = level.RandomizeScreens(random, ref screenAttempts);
-                    if (!result)
+                    bool screenResult = level.RandomizeScreens(random, ref screenAttempts);
+                    if (!screenResult)
                     {
-                        return result;
+                        message = "Screen randomization failed";
+                        return screenResult;
                     }
                 }
             }
@@ -55,6 +69,7 @@ namespace FaxanaduRando.Randomizer
             var itemRandomizer = new ItemRandomizer(random);
             if (!itemRandomizer.ShuffleItems(levels, shopRandomizer, giftRandomizer, doorRandomizer, content, out uint attempts))
             {
+                message = "Item randomization failed";
                 return false;
             }
 
@@ -302,8 +317,16 @@ namespace FaxanaduRando.Randomizer
                 textRandomizer.RandomizeTitles(content, customTextFile);
             }
 
-            if (!textRandomizer.UpdateText(shopRandomizer, giftRandomizer, doorRandomizer, content, customTextFile))
+            var result = textRandomizer.UpdateText(shopRandomizer, giftRandomizer, doorRandomizer, content, customTextFile);
+            if (result != Result.Success)
             {
+                if (result == Result.TextTooLong)
+                {
+                    message = "Text randomization failed, generated text was too long for this seed";
+                    return false;
+                }
+
+                message = "Text randomization failed";
                 return false;
             }
 

--- a/FaxanaduRando/Randomizer/TextOptions.cs
+++ b/FaxanaduRando/Randomizer/TextOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace FaxanaduRando.Randomizer
+{
+    public class TextOptions
+    {
+        public static bool UseCustomText { get; set; } = false;
+    }
+}

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace FaxanaduRando.Randomizer
 {
@@ -49,10 +50,11 @@ namespace FaxanaduRando.Randomizer
             titleRewards = GetTitleData(content, Section.GetOffset(15, 0xF767, 0xC000));
         }
 
-        public bool UpdateText(ShopRandomizer shopRandomizer, GiftRandomizer giftRandomizer, DoorRandomizer doorRandomizer, byte[] content)
+        public bool UpdateText(ShopRandomizer shopRandomizer, GiftRandomizer giftRandomizer, DoorRandomizer doorRandomizer, byte[] content, string customTextFile)
         {
             var allText = Text.GetAllText(content);
             int oldLength = getLength(allText);
+            var customTexts = new List<string>() {};
 
             if (GeneralOptions.FastText)
             {
@@ -71,6 +73,13 @@ namespace FaxanaduRando.Randomizer
                     hints = GetHints(shopRandomizer, giftRandomizer, doorRandomizer);
                 }
 
+                // notes; 38 & 39 first NPC pre- and post- King talk
+                /* known indices
+
+                    38: first NPC, pre-King talk
+                    39: first NPC, post-King talk
+                */
+
                 var indices = new List<int> { 38, 39, 41, 42, 45, 46, 47, 48, 49, 50,
                                               51, 54, 55,
                                               56, 57, 58, 59, 60,
@@ -86,8 +95,8 @@ namespace FaxanaduRando.Randomizer
                                               150, 151,
                                               154, 155, 156, 157, 158, 159 };
 
-                var communityHints = new List<string>()
-                {
+            var communityHints = new List<string>()
+            {
                     "Hi",
                     "Ni",
                     "Who's talkin'?",
@@ -123,9 +132,34 @@ namespace FaxanaduRando.Randomizer
                     "Shoutout to OdinSpack",
                     "Shoutout to MeowthRocket",
                     "Shoutout to Songbirder",
+                    "Shoutout to Bogledowdee",
                 };
 
+                if (!string.IsNullOrEmpty(customTextFile)) {
+    
+                    string[] customTextLines = File.ReadAllLines(customTextFile); 
+
+                    communityHints = new List<string>() {};
+                    foreach (string customText in customTextLines)
+                    {
+                        if (customText.Trim().StartsWith(":"))
+                        {
+                            communityHints.Add(customText.Remove(0,1));
+                        }
+                        else if (customText.Trim().StartsWith("title:"))
+                        {
+                            // do nothing
+                        }
+                        else
+                        {
+                            customTexts.Add(customText);
+                        }
+                    }
+                        
+                } 
+            
                 Util.ShuffleList(communityHints, 0, communityHints.Count - 1, random);
+
                 if (GeneralOptions.HintSetting == GeneralOptions.Hints.Community)
                 {
                     hints.AddRange(communityHints);
@@ -309,39 +343,46 @@ namespace FaxanaduRando.Randomizer
                 AddText("Hi", allText, 139); //Conflate guru
                 AddText("Hi", allText, 161); //Fraternal guru
 
+                foreach (string customText in customTexts)
+                {
+                    string[] parts = customText.Split(':');
+                    var textIndex = Int32.Parse(parts[0]);
+                    AddText(parts[1], allText, textIndex);
+                }
+
                 var price = shopRandomizer.StaticPriceDict[DoorId.MartialArtsShop].Price;
-                AddText($"Martial arts for {price}?", allText, 24);
+                AddText(GetMartialArtsText(price, GetCustomText(customTexts, 24)), allText, 24);
 
                 price = shopRandomizer.StaticPriceDict[DoorId.EolisMagicShop].Price;
-                AddText($"Magic for {price}?", allText, 20);
+                AddText(GetMagicShopText(price, GetCustomText(customTexts, 20)), allText, 20);
 
                 price = shopRandomizer.StaticPriceDict[DoorId.ApoluneHospital].Price;
-                AddText(GetHospitalText(price), allText, 27);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 27)), allText, 27);
                 price = shopRandomizer.StaticPriceDict[DoorId.ForepawHospital].Price;
-                AddText(GetHospitalText(price), allText, 28);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 28)), allText, 28);
                 price = shopRandomizer.StaticPriceDict[DoorId.MasconHospital].Price;
-                AddText(GetHospitalText(price), allText, 29);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 29)), allText, 29);
                 price = shopRandomizer.StaticPriceDict[DoorId.VictimHospital].Price;
-                AddText(GetHospitalText(price), allText, 30);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 30)), allText, 30);
                 price = shopRandomizer.StaticPriceDict[DoorId.ConflateHospital].Price;
-                AddText(GetHospitalText(price), allText, 31);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 31)), allText, 31);
                 price = shopRandomizer.StaticPriceDict[DoorId.DartmoorHospital].Price;
-                AddText(GetHospitalText(price), allText, 32);
+                AddText(GetHospitalText(price, GetCustomText(customTexts, 32)), allText, 32);
 
                 price = shopRandomizer.StaticPriceDict[DoorId.EolisMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 6);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 6)), allText, 6);
                 price = shopRandomizer.StaticPriceDict[DoorId.ForepawMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 7);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 7)), allText, 7);
                 price = shopRandomizer.StaticPriceDict[DoorId.MasconMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 8);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 8)), allText, 8);
                 price = shopRandomizer.StaticPriceDict[DoorId.VictimMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 9);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 9)), allText, 9);
                 price = shopRandomizer.StaticPriceDict[DoorId.ConflateMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 10);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 10)), allText, 10);
                 price = shopRandomizer.StaticPriceDict[DoorId.DaybreakMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 11);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 11)), allText, 11);
                 price = shopRandomizer.StaticPriceDict[DoorId.DartmoorMeatShop].Price;
-                AddText(GetMeatShopText(price), allText, 12);
+                AddText(GetMeatShopText(price, GetCustomText(customTexts, 12)), allText, 12);
             }
 
             int newLength = getLength(allText);
@@ -354,9 +395,16 @@ namespace FaxanaduRando.Randomizer
             return true;
         }
 
-        public void RandomizeTitles(byte[] content)
+        public void RandomizeTitles(byte[] content, string customTextFile)
         {
-            var newTitles = GetNewTitles();
+
+            var newTitles = customTextFile.Length > 0 ? GetCustomTitles(customTextFile) : GetNewTitles();
+
+            // if not enough titles are provided, then append existing list.
+            if (newTitles.Count < 16) {
+                newTitles.Concat(GetNewTitles()).ToList();
+            }
+
             Util.ShuffleList(newTitles, 0, newTitles.Count - 1, random);
             titles = newTitles.GetRange(0, titles.Count);
             Text.SetTitles(titles, content);
@@ -813,6 +861,22 @@ namespace FaxanaduRando.Randomizer
             }
         }
 
+        private List<string> GetCustomTitles(string customTextFile)
+        {
+
+            string[] customTextFileLines = File.ReadAllLines(customTextFile); 
+
+            var customTitles = new List<string>() {};
+            foreach (string line in customTextFileLines)
+            {
+                if (line.Trim().StartsWith("title:")) {
+                    customTitles.Add(line.Remove(0,6));
+                }
+            }
+
+            return customTitles;
+        }
+
         private List<string> GetNewTitles()
         {
             return new List<string>()
@@ -972,14 +1036,40 @@ namespace FaxanaduRando.Randomizer
             };
         }
 
-        private string GetHospitalText(ushort price)
+        private string GetCustomText(List<string> customTexts, int idNumber)
         {
-            return $"{price}?";
+            var customText = "";
+            foreach (string text in customTexts)
+            {
+                string[] parts = text.Split(':');
+
+                if (Int32.Parse(parts[0]) == idNumber)
+                {
+                    customText = parts[1];
+                }
+            }
+
+            return customText;
         }
 
-        private string GetMeatShopText(ushort price)
+        private string GetHospitalText(ushort price, string customText)
         {
-            return $"Eat my meat for {price}?";
+            return customText.Length > 0 ? String.Format(customText, price) : $"{price}?";;
+        }
+
+        private string GetMeatShopText(ushort price, string customText)
+        {
+            return customText.Length > 0 ? String.Format(customText, price) : $"Eat my meat for {price}?";
+        }
+
+        private string GetMartialArtsText(ushort price, string customText)
+        {
+            return customText.Length > 0 ? String.Format(customText, price) : $"Martial arts for {price}?";
+        }
+
+        private string GetMagicShopText(ushort price, string customText)
+        {
+            return customText.Length > 0 ? String.Format(customText, price) : $"Magic for {price}?";
         }
 
         private int getLength(List<string> texts)
@@ -998,14 +1088,56 @@ namespace FaxanaduRando.Randomizer
             texts[index] = text + Text.endOfTextChar;
         }
 
+        private string AddLine(string text, List<string> lines, int index, int previousIndex)
+        {
+            var length = index - previousIndex;
+            
+            var line = text.Substring(previousIndex, length);
+            var paddingMax = length > 14 ? 16 - length : 2;
+            var padding = "".PadRight(paddingMax < 0 ? 0 : paddingMax, ' ');
+
+            // bug: sometimes an extra line appears...
+            // probably not that big of a deal though.
+
+            if ((index >= 0) && (index < text.Length) && text[index] == '|')
+                line = line + Text.lineBreakWithPauseChar + padding;
+
+            return line;
+        }
+
         private string InsertLineBreaks(string text)
         {
             var indices = new List<int>();
 
             for (int i = 16; i < text.Length; i += 16)
             {
-                int j = i;
-                int k = j - 16;
+                bool indexed = false;
+                int j = i - 15;
+                int k = i;
+                int highest_j = 0;
+
+                while (j < k)
+                {
+                    if (text[j] == '|')
+                    {
+                        indices.Add(j);
+                        indexed = true;
+                        highest_j = j;
+                        // don't break as there could be more than one.
+                    }
+
+                    j++;
+                }
+
+                if (indexed == true)
+                {
+                    i = highest_j;
+                    continue;
+                }
+
+                j = i;
+                k = j - 16;
+
                 while (j > k)
                 {
                     if (text[j] == ' ')
@@ -1019,11 +1151,20 @@ namespace FaxanaduRando.Randomizer
                 }
             }
 
-            var newText = text;
+            var lines =  new List<string>();
+            int previousIndex = 0;
+
             foreach (var index in indices)
             {
-                newText = newText.Substring(0, index) + Text.lineBreakChar + text.Substring(index + 1);
+                var line = AddLine(text, lines, index, previousIndex);
+                lines.Add(line + Text.lineBreakChar.ToString());
+                previousIndex = index + 1; // add one to skip the space or pausebreak
             }
+
+            var lastLine = AddLine(text, lines, text.Length, previousIndex);
+            lines.Add(lastLine);
+
+            var newText = string.Join("", lines);
 
             return newText;
         }

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -50,7 +50,7 @@ namespace FaxanaduRando.Randomizer
             titleRewards = GetTitleData(content, Section.GetOffset(15, 0xF767, 0xC000));
         }
 
-        public bool UpdateText(ShopRandomizer shopRandomizer, GiftRandomizer giftRandomizer, DoorRandomizer doorRandomizer, byte[] content, string customTextFile)
+        public Result UpdateText(ShopRandomizer shopRandomizer, GiftRandomizer giftRandomizer, DoorRandomizer doorRandomizer, byte[] content, string customTextFile)
         {
             var allText = Text.GetAllText(content);
             int oldLength = getLength(allText);
@@ -393,11 +393,11 @@ namespace FaxanaduRando.Randomizer
             int newLength = getLength(allText);
             if (newLength > oldLength)
             {
-                return false;
+                return Result.TextTooLong;
             }
 
             Text.SetAllText(content, allText);
-            return true;
+            return Result.Success;
         }
 
         public void RandomizeTitles(byte[] content, string customTextFile)

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -402,7 +402,7 @@ namespace FaxanaduRando.Randomizer
 
             // if not enough titles are provided, then append existing list.
             if (newTitles.Count < 16) {
-                newTitles.Concat(GetNewTitles()).ToList();
+                newTitles.AddRange(GetNewTitles());
             }
 
             Util.ShuffleList(newTitles, 0, newTitles.Count - 1, random);

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -404,9 +404,12 @@ namespace FaxanaduRando.Randomizer
         {
             var newTitles = TextOptions.UseCustomText ? GetCustomTitles(customTextFile) : GetNewTitles();
 
-            // if not enough titles are provided, then append existing list.
-            if (newTitles.Count < 16) {
-                newTitles.AddRange(GetNewTitles());
+            // if not enough titles are provided, then append existing titles.
+            if (newTitles.Count < 16)
+            {
+                var standardTitles = GetNewTitles();
+                Util.ShuffleList(standardTitles, 0, standardTitles.Count - 1, random);
+                newTitles.AddRange(standardTitles.GetRange(0, 16 - newTitles.Count));
             }
 
             Util.ShuffleList(newTitles, 0, newTitles.Count - 1, random);

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -55,6 +55,7 @@ namespace FaxanaduRando.Randomizer
             var allText = Text.GetAllText(content);
             int oldLength = getLength(allText);
             var customTexts = new List<string>() {};
+            string defaultHint = "Hi";
 
             if (GeneralOptions.FastText)
             {
@@ -97,7 +98,7 @@ namespace FaxanaduRando.Randomizer
 
             var communityHints = new List<string>()
             {
-                    "Hi",
+                    defaultHint,
                     "Ni",
                     "Who's talkin'?",
                     "I am Error",
@@ -135,8 +136,8 @@ namespace FaxanaduRando.Randomizer
                     "Shoutout to Bogledowdee",
                 };
 
-                if (!string.IsNullOrEmpty(customTextFile)) {
-    
+                if (TextOptions.UseCustomText)
+                {
                     string[] customTextLines = File.ReadAllLines(customTextFile); 
 
                     communityHints = new List<string>() {};
@@ -144,7 +145,11 @@ namespace FaxanaduRando.Randomizer
                     {
                         if (customText.Trim().StartsWith(":"))
                         {
-                            communityHints.Add(customText.Remove(0,1));
+                            communityHints.Add(customText.Remove(0, 1));
+                        }
+                        else if (customText.Trim().StartsWith("default:"))
+                        {
+                            defaultHint = customText.Split(':')[1];
                         }
                         else if (customText.Trim().StartsWith("title:"))
                         {
@@ -155,7 +160,6 @@ namespace FaxanaduRando.Randomizer
                             customTexts.Add(customText);
                         }
                     }
-                        
                 } 
             
                 Util.ShuffleList(communityHints, 0, communityHints.Count - 1, random);
@@ -167,6 +171,7 @@ namespace FaxanaduRando.Randomizer
 
                 int index = 0;
                 int communityHintCount = GeneralOptions.HintSetting == GeneralOptions.Hints.Strong ? 2 : 10;
+                communityHintCount = Math.Min(communityHintCount, communityHints.Count);
                 for (; index < communityHintCount; index++)
                 {
                     hints.Add(communityHints[index]);
@@ -180,7 +185,7 @@ namespace FaxanaduRando.Randomizer
 
                 while (hints.Count < indices.Count)
                 {
-                    hints.Add("Hi");
+                    hints.Add(defaultHint);
                 }
 
                 Util.ShuffleList(hints, 0, hints.Count - 1, random);
@@ -328,7 +333,7 @@ namespace FaxanaduRando.Randomizer
                 else
                 {
                     //Intro text
-                    AddText("Hi", allText, 37);
+                    AddText(defaultHint, allText, 37);
                 }
 
                 var kingTexts = new List<string>()
@@ -337,16 +342,16 @@ namespace FaxanaduRando.Randomizer
                 };
 
                 AddText(kingTexts[random.Next(kingTexts.Count)], allText, 52);
-                AddText("Hi", allText, 43); //Eolis guru
-                AddText("Hi", allText, 86); //Sky fountain
-                AddText("Hi", allText, 125); //Ace key guy
-                AddText("Hi", allText, 139); //Conflate guru
-                AddText("Hi", allText, 161); //Fraternal guru
+                AddText(defaultHint, allText, 43); //Eolis guru
+                AddText(defaultHint, allText, 86); //Sky fountain
+                AddText(defaultHint, allText, 125); //Ace key guy
+                AddText(defaultHint, allText, 139); //Conflate guru
+                AddText(defaultHint, allText, 161); //Fraternal guru
 
                 foreach (string customText in customTexts)
                 {
                     string[] parts = customText.Split(':');
-                    var textIndex = Int32.Parse(parts[0]);
+                    var textIndex = int.Parse(parts[0]);
                     AddText(parts[1], allText, textIndex);
                 }
 
@@ -397,8 +402,7 @@ namespace FaxanaduRando.Randomizer
 
         public void RandomizeTitles(byte[] content, string customTextFile)
         {
-
-            var newTitles = customTextFile.Length > 0 ? GetCustomTitles(customTextFile) : GetNewTitles();
+            var newTitles = TextOptions.UseCustomText ? GetCustomTitles(customTextFile) : GetNewTitles();
 
             // if not enough titles are provided, then append existing list.
             if (newTitles.Count < 16) {
@@ -863,7 +867,6 @@ namespace FaxanaduRando.Randomizer
 
         private List<string> GetCustomTitles(string customTextFile)
         {
-
             string[] customTextFileLines = File.ReadAllLines(customTextFile); 
 
             var customTitles = new List<string>() {};
@@ -1043,9 +1046,10 @@ namespace FaxanaduRando.Randomizer
             {
                 string[] parts = text.Split(':');
 
-                if (Int32.Parse(parts[0]) == idNumber)
+                if (int.Parse(parts[0]) == idNumber)
                 {
                     customText = parts[1];
+                    break;
                 }
             }
 
@@ -1054,22 +1058,22 @@ namespace FaxanaduRando.Randomizer
 
         private string GetHospitalText(ushort price, string customText)
         {
-            return customText.Length > 0 ? String.Format(customText, price) : $"{price}?";;
+            return customText.Length > 0 ? string.Format(customText, price) : $"{price}?";;
         }
 
         private string GetMeatShopText(ushort price, string customText)
         {
-            return customText.Length > 0 ? String.Format(customText, price) : $"Eat my meat for {price}?";
+            return customText.Length > 0 ? string.Format(customText, price) : $"Eat my meat for {price}?";
         }
 
         private string GetMartialArtsText(ushort price, string customText)
         {
-            return customText.Length > 0 ? String.Format(customText, price) : $"Martial arts for {price}?";
+            return customText.Length > 0 ? string.Format(customText, price) : $"Martial arts for {price}?";
         }
 
         private string GetMagicShopText(ushort price, string customText)
         {
-            return customText.Length > 0 ? String.Format(customText, price) : $"Magic for {price}?";
+            return customText.Length > 0 ? string.Format(customText, price) : $"Magic for {price}?";
         }
 
         private int getLength(List<string> texts)
@@ -1108,65 +1112,95 @@ namespace FaxanaduRando.Randomizer
         private string InsertLineBreaks(string text)
         {
             var indices = new List<int>();
-
-            for (int i = 16; i < text.Length; i += 16)
+            if (TextOptions.UseCustomText)
             {
-                bool indexed = false;
-                int j = i - 15;
-                int k = i;
-                int highest_j = 0;
-
-                while (j < k)
+                for (int i = 16; i < text.Length; i += 16)
                 {
-                    if (text[j] == '|')
+                    bool indexed = false;
+                    int j = i - 15;
+                    int k = i;
+                    int highest_j = 0;
+
+                    while (j < k)
                     {
-                        indices.Add(j);
-                        indexed = true;
-                        highest_j = j;
-                        // don't break as there could be more than one.
+                        if (text[j] == '|')
+                        {
+                            indices.Add(j);
+                            indexed = true;
+                            highest_j = j;
+                            // don't break as there could be more than one.
+                        }
+
+                        j++;
                     }
 
-                    j++;
-                }
-
-                if (indexed == true)
-                {
-                    i = highest_j;
-                    continue;
-                }
-
-                j = i;
-                k = j - 16;
-
-                while (j > k)
-                {
-                    if (text[j] == ' ')
+                    if (indexed == true)
                     {
-                        indices.Add(j);
-                        i = j;
-                        break;
+                        i = highest_j;
+                        continue;
                     }
 
-                    j--;
+                    j = i;
+                    k = j - 16;
+
+                    while (j > k)
+                    {
+                        if (text[j] == ' ')
+                        {
+                            indices.Add(j);
+                            i = j;
+                            break;
+                        }
+
+                        j--;
+                    }
                 }
+
+                var lines = new List<string>();
+                int previousIndex = 0;
+
+                foreach (var index in indices)
+                {
+                    var line = AddLine(text, lines, index, previousIndex);
+                    lines.Add(line + Text.lineBreakChar.ToString());
+                    previousIndex = index + 1; // add one to skip the space or pausebreak
+                }
+
+                var lastLine = AddLine(text, lines, text.Length, previousIndex);
+                lines.Add(lastLine);
+
+                var newText = string.Join("", lines);
+
+                return newText;
             }
-
-            var lines =  new List<string>();
-            int previousIndex = 0;
-
-            foreach (var index in indices)
+            else
             {
-                var line = AddLine(text, lines, index, previousIndex);
-                lines.Add(line + Text.lineBreakChar.ToString());
-                previousIndex = index + 1; // add one to skip the space or pausebreak
+
+                for (int i = 16; i < text.Length; i += 16)
+                {
+                    int j = i;
+                    int k = j - 16;
+                    while (j > k)
+                    {
+                        if (text[j] == ' ')
+                        {
+                            indices.Add(j);
+                            i = j;
+                            break;
+                        }
+
+                        j--;
+                    }
+                }
+
+                var newText = text;
+                foreach (var index in indices)
+                {
+                    newText = newText.Substring(0, index) + Text.lineBreakChar + text.Substring(index + 1);
+                }
+
+                return newText;
             }
-
-            var lastLine = AddLine(text, lines, text.Length, previousIndex);
-            lines.Add(lastLine);
-
-            var newText = string.Join("", lines);
-
-            return newText;
         }
 
         private List<string> GetAllSublevelHints(GiftRandomizer giftRandomizer, bool spoilerLog)


### PR DESCRIPTION
This adds in the ability to provide a text file that will replace a lot of the randomized text with your own text. Great for streamers looking to have their own custom jokes and so on.

Attaching an example file.

Here's some example lines in the format they need to be in:

For the "community hints":
```
:This is a community hint.
```

For dialog number 39:
```
39:This text will appear for the first visible NPC so long as you have visited the King.
```

For places like shops that need templating:
```
6:This text will be useful for replacing shop texts as it can insert the cost {0} with templating.
```

For custom titles:
```
title:CustomTitle
```

Also: added support for the "pause" character, for really long texts.
```
39:We can't bust heads like we used to-|but we have our ways.|One trick is to tell them stories|that don't go anywhere like the time I caught the ferry|over to Shelbyville.|I needed a new heel for my shoe,|so I decided to go to Morganville|which is what they called Shelbyville in those days.|So, I tied an onion to my belt|which was the style at the time.|Now, to take the ferry cost a nickel.|And in those days, nickels had pictures of bumblebees on 'em.|"Give me five bees for a quarter," you'd say.|Now, where were we?|Oh, yeah!|The important thing was that I had an onion on my belt|which was the style at the time.|They didn't have white onions because of THE WAR.|The only thing you could get was those big yellow ones...
```
[hints.txt](https://github.com/Notlobb/Randumizer/files/10248484/hints.txt)
