### PR TITLE
Make ROM generation deterministic for identical input

### DIFF
--- a/FaxanaduRando/Randomizer/ItemDialog.cs
+++ b/FaxanaduRando/Randomizer/ItemDialog.cs
@@ -6,7 +6,6 @@ namespace FaxanaduRando.Randomizer
 {
     public static class ItemDialog
     {
-        private static readonly Random RandomGenerator = new Random();
 
         public enum Id
         {
@@ -157,6 +156,7 @@ namespace FaxanaduRando.Randomizer
         };
 
         public static Dictionary<int, string> GetDialog(
+            Random RandomGenerator,
             Dictionary<Item, string> itemOptions,
             string customTextFile = null)
         {
@@ -197,7 +197,8 @@ namespace FaxanaduRando.Randomizer
                             ? AlternativeDialogTemplates[id][RandomGenerator.Next(AlternativeDialogTemplates[id].Count)]
                             : AlternativeDialogTemplates.ContainsKey(id) ? AlternativeDialogTemplates[id][0] : null;
                 }
-                else {
+                else
+                {
                     template = customTemplates.ContainsKey(id)
                         ? customTemplates[id]
                         : GeneralOptions.UpdateMiscText && DialogTemplates.ContainsKey(id)

--- a/FaxanaduRando/Randomizer/ItemNameRandomizer.cs
+++ b/FaxanaduRando/Randomizer/ItemNameRandomizer.cs
@@ -144,7 +144,7 @@ namespace FaxanaduRando.Randomizer
             { Item.Poison, new List<string> { "Poison", "Venom", "Toxin", "Bane Juice" } }
         };
 
-        public static Dictionary<Item, string> GenerateItemNameDictionary(bool randomize, string customTextFile = null)
+        public static Dictionary<Item, string> GenerateItemNameDictionary(Random random, bool randomize, string customTextFile = null)
         {
             var itemDictionary = new Dictionary<Item, string>();
 
@@ -152,7 +152,7 @@ namespace FaxanaduRando.Randomizer
             {
                 if (randomize)
                 {
-                    var randomValue = item.Value[new Random().Next(item.Value.Count)];
+                    var randomValue = item.Value[random.Next(item.Value.Count)];
                     itemDictionary[item.Key] = randomValue;
                 }
                 else

--- a/FaxanaduRando/Randomizer/Randomizer.cs
+++ b/FaxanaduRando/Randomizer/Randomizer.cs
@@ -316,11 +316,7 @@ namespace FaxanaduRando.Randomizer
             var titleText = Text.GetAllTitleText(content, Section.GetOffset(12, 0x9DCC, 0x8000),
                                                  Section.GetOffset(12, 0x9E0D, 0x8000));
             Text.AddTitleText(0, "RANDUMIZER V29B4", titleText);
-            var hash = ((uint)flags.GetHashCode()).ToString();
-            if (hash.Length > 8)
-            {
-                hash = hash.Substring(0, 8);
-            }
+            var hash = Util.Fnv1aHash(flags).ToString("X8");
 
             Text.AddTitleText(1, $"FLAG HASH {hash}", titleText);
             Text.AddTitleText(2, $"SEED {seed}", titleText);

--- a/FaxanaduRando/Randomizer/TextRandomizer.cs
+++ b/FaxanaduRando/Randomizer/TextRandomizer.cs
@@ -301,6 +301,7 @@ namespace FaxanaduRando.Randomizer
 
                 Dictionary<Item, string> itemDictionary =
                     ItemNameRandomizer.GenerateItemNameDictionary(
+                        this.random,
                         ItemOptions.RandomizeItemNames,
                         customTextFile
                     );
@@ -321,7 +322,7 @@ namespace FaxanaduRando.Randomizer
 
                 Text.SetAllItemNames(content, intBasedDictionary);
 
-                var itemDialogs = ItemDialog.GetDialog(itemDictionary, customTextFile);
+                var itemDialogs = ItemDialog.GetDialog(this.random, itemDictionary, customTextFile);
 
                 foreach (var dialog in itemDialogs)
                 {

--- a/FaxanaduRando/Randomizer/Util.cs
+++ b/FaxanaduRando/Randomizer/Util.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace FaxanaduRando.Randomizer
 {
@@ -81,6 +82,23 @@ namespace FaxanaduRando.Randomizer
             var pointer = BitConverter.ToUInt16(bytes, 0);
 
             return pointer;
+        }
+
+        // canonical 32-bit Fowler–Noll–Vo (FNV-1a) hash
+        public static uint Fnv1aHash(string text)
+        {
+            const uint offsetBasis = 2166136261;
+            const uint prime = 16777619;
+
+            uint hash = offsetBasis;
+
+            foreach (byte b in Encoding.UTF8.GetBytes(text))
+            {
+                hash ^= b;
+                hash *= prime;
+            }
+
+            return hash;
         }
     }
 }


### PR DESCRIPTION
This fixes a couple of sources of nondeterminism so the randomizer now produces identical ROMs for identical input (ROM, seed, flags, and custom text).

The changes are:

Use the existing seeded Random instance downstream for all randomized item names and dialog instead of creating time-seeded Random objects.

Replace the title-screen flag hash based on the intentionally non-deterministic string.GetHashCode() with a deterministic 32-bit [FNV-1a hash](<https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function>).

This is an improvement for both players and developers. Players can now reliably regenerate the exact same ROM by using the same seed and settings. For development, it makes regression testing and binary comparisons much easier, since any differences in the output now indicate a real change rather than nondeterministic behavior.